### PR TITLE
DEV-520:CHANGE: HTTP subscriptions use timestamp of last received entity for polling requests

### DIFF
--- a/internal/transport/apirequests/pendingrequest.go
+++ b/internal/transport/apirequests/pendingrequest.go
@@ -5,9 +5,9 @@
 package apirequests
 
 type PendingRequest struct {
-	Data       chan []byte
-	Err        chan error
-	Signal     chan struct{}
+	Data   chan []byte
+	Err    chan error
+	Signal chan struct{}
 }
 
 func (r *PendingRequest) Close() {

--- a/internal/transport/apirequests/pendingrequestsmap.go
+++ b/internal/transport/apirequests/pendingrequestsmap.go
@@ -28,7 +28,7 @@ func (m *PendingRequestsMap) Delete(key string) {
 
 func (m *PendingRequestsMap) CreateRequest(key string) *PendingRequest {
 	req := &PendingRequest{
-		Data:   make(chan []byte, 16),
+		Data:   make(chan []byte),
 		Signal: make(chan struct{}),
 		Err:    make(chan error),
 	}

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -41,12 +41,12 @@ func newHTTP(addr string) (*HTTP, error) {
 }
 
 type HTTP struct {
-	url                		*url.URL
-	subscriptions      		*apirequests.PendingRequestsMap
-	pollingAccessToken 		string
+	url                     *url.URL
+	subscriptions           *apirequests.PendingRequestsMap
+	pollingAccessToken      string
 	pollingAccessTokenMutex sync.RWMutex
-	pollResourcesMutex 		sync.RWMutex
-	pollResources	   		map[string]string
+	pollResourcesMutex      sync.RWMutex
+	pollResources           map[string]string
 }
 
 func (t *HTTP) IsHTTP() bool {
@@ -197,7 +197,7 @@ func (t *HTTP) Subscribe(resource string, params *RequestParams) (subscription *
 				subs.Err <- err
 			case res := <-resChan:
 				subs.Data <- res
-			case <- signalChan:
+			case <-signalChan:
 				continueChan <- struct{}{}
 			case <-subs.Signal:
 				close(subs.Data)
@@ -234,7 +234,7 @@ func (t *HTTP) poll(subsId string, params *RequestParams, done chan struct{}) (c
 			params.AccessToken = t.pollingAccessToken
 			t.pollingAccessTokenMutex.RUnlock()
 
-			<- continueChan
+			<-continueChan
 
 			t.pollResourcesMutex.RLock()
 			resource := t.pollResources[subsId]

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/devicehive/devicehive-go/internal/transport/apirequests"
-	"fmt"
 )
 
 const (
@@ -240,8 +239,6 @@ func (t *HTTP) poll(subsId string, params *RequestParams, done chan struct{}) (c
 			t.pollResourcesMutex.RLock()
 			resource := t.pollResources[subsId]
 			t.pollResourcesMutex.RUnlock()
-
-			fmt.Println("Polling", resource)
 
 			res, err := t.Request(resource, params, timeout)
 			if err != nil {

--- a/internal/transport/subscription.go
+++ b/internal/transport/subscription.go
@@ -3,4 +3,9 @@ package transport
 type Subscription struct {
 	DataChan chan []byte
 	ErrChan  chan error
+	signal   chan struct{}
+}
+
+func (s *Subscription) ContinuePolling() {
+	s.signal <- struct{}{}
 }

--- a/internal/transportadapter/httpadapter.go
+++ b/internal/transportadapter/httpadapter.go
@@ -14,9 +14,13 @@ import (
 	"github.com/devicehive/devicehive-go/internal/transport"
 )
 
+type Timestamp struct {
+	Value string `json:"timestamp"`
+}
+
 type HTTPAdapter struct {
-	transport   *transport.HTTP
-	accessToken string
+	transport   	   *transport.HTTP
+	accessToken 	   string
 }
 
 type httpResponse struct {
@@ -58,13 +62,13 @@ func (a *HTTPAdapter) Subscribe(resourceName string, pollingWaitTimeoutSeconds i
 		return nil, "", tspErr
 	}
 
-	subscription = a.transformSubscription(tspSubs)
+	subscription = a.transformSubscription(resourceName, subscriptionId, params, tspSubs)
 
 	return subscription, subscriptionId, nil
 }
 
-func (a *HTTPAdapter) transformSubscription(subs *transport.Subscription) *transport.Subscription {
-	dataChan := make(chan []byte, 16)
+func (a *HTTPAdapter) transformSubscription(resourceName, subscriptionId string, params map[string]interface{}, subs *transport.Subscription) *transport.Subscription {
+	dataChan := make(chan []byte)
 	errChan := make(chan error)
 
 	go func() {
@@ -82,6 +86,9 @@ func (a *HTTPAdapter) transformSubscription(subs *transport.Subscription) *trans
 					continue
 				}
 
+				a.setResourceWithLastTimestamp(resourceName, subscriptionId, params, list)
+				subs.ContinuePolling()
+
 				for _, data := range list {
 					dataChan <- data
 				}
@@ -91,6 +98,7 @@ func (a *HTTPAdapter) transformSubscription(subs *transport.Subscription) *trans
 				}
 
 				errChan <- err
+				subs.ContinuePolling()
 			}
 		}
 
@@ -117,6 +125,29 @@ func (a *HTTPAdapter) handleSubscriptionEventData(data []byte) ([]json.RawMessag
 	}
 
 	return list, nil
+}
+
+func (a *HTTPAdapter) setResourceWithLastTimestamp(resourceName, subscriptionId string, params map[string]interface{}, list []json.RawMessage) {
+	l := len(list)
+	if l == 0 {
+		return
+	}
+
+	timestamp := &Timestamp{}
+	json.Unmarshal(list[l - 1], timestamp)
+
+	if timestamp.Value == "" {
+		return
+	}
+
+	if params == nil {
+		params = make(map[string]interface{})
+	}
+	params["timestamp"] = timestamp.Value
+
+	resource, _ := a.resolveResource(resourceName, params)
+
+	a.transport.SetPollingResource(subscriptionId, resource)
 }
 
 func (a *HTTPAdapter) Unsubscribe(resourceName, subscriptionId string, timeout time.Duration) error {

--- a/internal/transportadapter/httpadapter.go
+++ b/internal/transportadapter/httpadapter.go
@@ -19,8 +19,8 @@ type Timestamp struct {
 }
 
 type HTTPAdapter struct {
-	transport   	   *transport.HTTP
-	accessToken 	   string
+	transport   *transport.HTTP
+	accessToken string
 }
 
 type httpResponse struct {
@@ -134,7 +134,7 @@ func (a *HTTPAdapter) setResourceWithLastTimestamp(resourceName, subscriptionId 
 	}
 
 	timestamp := &Timestamp{}
-	json.Unmarshal(list[l - 1], timestamp)
+	json.Unmarshal(list[l-1], timestamp)
 
 	if timestamp.Value == "" {
 		return

--- a/internal/transportadapter/httpadapter.go
+++ b/internal/transportadapter/httpadapter.go
@@ -86,7 +86,7 @@ func (a *HTTPAdapter) transformSubscription(resourceName, subscriptionId string,
 					continue
 				}
 
-				a.setResourceWithLastTimestamp(resourceName, subscriptionId, params, list)
+				a.setResourceWithLastEntityTimestamp(resourceName, subscriptionId, params, list)
 				subs.ContinuePolling()
 
 				for _, data := range list {
@@ -127,7 +127,7 @@ func (a *HTTPAdapter) handleSubscriptionEventData(data []byte) ([]json.RawMessag
 	return list, nil
 }
 
-func (a *HTTPAdapter) setResourceWithLastTimestamp(resourceName, subscriptionId string, params map[string]interface{}, list []json.RawMessage) {
+func (a *HTTPAdapter) setResourceWithLastEntityTimestamp(resourceName, subscriptionId string, params map[string]interface{}, list []json.RawMessage) {
 	l := len(list)
 	if l == 0 {
 		return

--- a/internal/transportadapter/wsadapter.go
+++ b/internal/transportadapter/wsadapter.go
@@ -68,7 +68,7 @@ func (a *WSAdapter) Subscribe(resourceName string, pollingWaitTimeoutSeconds int
 }
 
 func (a *WSAdapter) transformSubscription(resourceName string, subs *transport.Subscription) *transport.Subscription {
-	dataChan := make(chan []byte, 16)
+	dataChan := make(chan []byte)
 
 	go func() {
 		for d := range subs.DataChan {

--- a/test/dh/client_test.go
+++ b/test/dh/client_test.go
@@ -15,11 +15,11 @@ var testTokens = []byte(`{"accessToken":"test","refreshToken":"test"}`)
 var response401 = []byte(`{"timestamp":"2018-05-25T05:20:44.181","status":401,"error":"Unauthorized","message":"Token expired"}`)
 
 func TestReauthorizationByCreds(t *testing.T) {
-	httpSrv, httpAddr, httpClose := stubs.StartHTTPTestServer()
-	defer httpClose()
+	httpSrv, httpAddr := stubs.StartHTTPTestServer()
+	defer httpSrv.Close()
 
 	requestCount := 0
-	httpSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter) {
+	httpSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
 		requestCount++
 
 		if requestCount == 2 {
@@ -54,11 +54,11 @@ func TestReauthorizationByCreds(t *testing.T) {
 }
 
 func TestReauthorizationByRefreshToken(t *testing.T) {
-	httpSrv, httpAddr, httpClose := stubs.StartHTTPTestServer()
-	defer httpClose()
+	httpSrv, httpAddr := stubs.StartHTTPTestServer()
+	defer httpSrv.Close()
 
 	requestCount := 0
-	httpSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter) {
+	httpSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
 		requestCount++
 
 		if requestCount == 1 {

--- a/test/stubs/httpserverstub.go
+++ b/test/stubs/httpserverstub.go
@@ -11,14 +11,14 @@ import (
 	"net/http/httptest"
 )
 
-func StartHTTPTestServer() (srv *HTTPTestServer, addr string, closeSrv func()) {
+func StartHTTPTestServer() (srv *HTTPTestServer, addr string) {
 	srv = &HTTPTestServer{}
 	addr = srv.Start()
 
-	return srv, addr, srv.Close
+	return srv, addr
 }
 
-type httpRequestHandler func(reqData map[string]interface{}, rw http.ResponseWriter)
+type httpRequestHandler func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request)
 
 type HTTPTestServer struct {
 	reqHandler httpRequestHandler
@@ -48,7 +48,7 @@ func (s *HTTPTestServer) Start() (srvAddr string) {
 			}
 		}
 
-		s.reqHandler(data, w)
+		s.reqHandler(data, w, r)
 	})
 	srv := httptest.NewServer(h)
 
@@ -65,7 +65,7 @@ func (s *HTTPTestServer) SetRequestHandler(h httpRequestHandler) {
 	s.reqHandler = h
 }
 
-func defaultHTTPHandler(reqData map[string]interface{}, rw http.ResponseWriter) {
+func defaultHTTPHandler(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
 	res, err := json.Marshal(reqData)
 
 	if err != nil {

--- a/test/transport/http_test.go
+++ b/test/transport/http_test.go
@@ -48,7 +48,7 @@ func TestHTTPTimeout(t *testing.T) {
 	is := is.New(t)
 
 	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
-		<-time.After(testWSTimeout + 1*time.Second)
+		<-time.After(testHTTPTimeout + 1*time.Second)
 		rw.Write([]byte("{\"result\": \"success\"}"))
 	})
 
@@ -68,17 +68,14 @@ func TestHTTPSubscription(t *testing.T) {
 
 	is := is.New(t)
 
-	pollRequestsCount := 0
-	const allowedPollRequestsCount = 3
+	pollReqHandled := false
 	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
-		if pollRequestsCount >= allowedPollRequestsCount {
-			t.Error("HTTP transport must stop polling after unsubscribe")
-			return
+		if pollReqHandled {
+			t.Fatal("HTTP transport must stop polling after unsubscription")
 		}
 
-		<-time.After(testWSTimeout + 1*time.Second)
 		rw.Write([]byte(`[{"id": 1,"command": "command 1"},{"id": 2,"command": "command 2"}]`))
-		pollRequestsCount++
+		pollReqHandled = true
 	})
 
 	httpTsp, err := transport.Create(addr)
@@ -95,15 +92,9 @@ func TestHTTPSubscription(t *testing.T) {
 	case data, ok := <-tspChan.DataChan:
 		is.True(ok)
 		is.True(data != nil)
-	case <-time.After(2 * time.Second):
-		t.Error("subscription event timeout")
-	}
-
-	select {
-	case data, ok := <-tspChan.DataChan:
-		is.True(ok)
-		is.True(data != nil)
-	case <-time.After(2 * time.Second):
+	case err := <- tspChan.ErrChan:
+		t.Fatal(err)
+	case <-time.After(testHTTPTimeout):
 		t.Error("subscription event timeout")
 	}
 

--- a/test/transport/http_test.go
+++ b/test/transport/http_test.go
@@ -16,12 +16,12 @@ import (
 const testHTTPTimeout = 300 * time.Millisecond
 
 func TestHTTPRequestId(t *testing.T) {
-	httpTestSrv, addr, srvClose := stubs.StartHTTPTestServer()
-	defer srvClose()
+	httpTestSrv, addr := stubs.StartHTTPTestServer()
+	defer httpTestSrv.Close()
 
 	is := is.New(t)
 
-	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter) {
+	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
 		is.True(reqData["requestId"] != "")
 		rw.Write([]byte("{}"))
 	})
@@ -42,12 +42,12 @@ func TestHTTPRequestId(t *testing.T) {
 }
 
 func TestHTTPTimeout(t *testing.T) {
-	httpTestSrv, addr, srvClose := stubs.StartHTTPTestServer()
-	defer srvClose()
+	httpTestSrv, addr := stubs.StartHTTPTestServer()
+	defer httpTestSrv.Close()
 
 	is := is.New(t)
 
-	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter) {
+	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
 		<-time.After(testWSTimeout + 1*time.Second)
 		rw.Write([]byte("{\"result\": \"success\"}"))
 	})
@@ -63,14 +63,14 @@ func TestHTTPTimeout(t *testing.T) {
 }
 
 func TestHTTPSubscription(t *testing.T) {
-	httpTestSrv, addr, srvClose := stubs.StartHTTPTestServer()
-	defer srvClose()
+	httpTestSrv, addr := stubs.StartHTTPTestServer()
+	defer httpTestSrv.Close()
 
 	is := is.New(t)
 
 	pollRequestsCount := 0
 	const allowedPollRequestsCount = 3
-	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter) {
+	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
 		if pollRequestsCount >= allowedPollRequestsCount {
 			t.Error("HTTP transport must stop polling after unsubscribe")
 			return

--- a/test/transportadapter/httpadapter_test.go
+++ b/test/transportadapter/httpadapter_test.go
@@ -1,0 +1,69 @@
+package transportadapter
+
+import (
+	"testing"
+	"github.com/devicehive/devicehive-go/test/stubs"
+	"github.com/devicehive/devicehive-go/internal/transport"
+	"github.com/devicehive/devicehive-go/internal/transportadapter"
+	"github.com/devicehive/devicehive-go"
+	"time"
+	"net/http"
+	"encoding/json"
+	"fmt"
+)
+
+func TestHTTPSubscriptionLastEntityTimestamp(t *testing.T) {
+	httpTestSrv, addr := stubs.StartHTTPTestServer()
+	defer httpTestSrv.Close()
+
+	now := &devicehive_go.ISO8601Time{time.Now()}
+	commandTimestamp := (&devicehive_go.ISO8601Time{now.Add(1 * time.Second)}).String()
+	nextCommandTimestamp := (&devicehive_go.ISO8601Time{now.Add(2 * time.Second)}).String()
+
+	httpTestSrv.SetRequestHandler(func(reqData map[string]interface{}, rw http.ResponseWriter, r *http.Request) {
+		timestamp := r.URL.Query()["timestamp"][0]
+		if timestamp == now.String() {
+			rw.Write([]byte(fmt.Sprintf(`[{"id":1,"timestamp":%q}]`, commandTimestamp)))
+		} else if timestamp == commandTimestamp {
+			rw.Write([]byte(fmt.Sprintf(`[{"id":2,"timestamp":%q}]`, nextCommandTimestamp)))
+		} else {
+			rw.Write([]byte(fmt.Sprintf(`[{"id":"success","timestamp":%q}]`, nextCommandTimestamp)))
+		}
+	})
+
+	httpTsp, err := transport.Create(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tspAdapter := transportadapter.New(httpTsp)
+
+	params := map[string]interface{}{
+		"timestamp": now.String(),
+	}
+	subs, _, subsErr := tspAdapter.Subscribe("subscribeCommands", 1, params)
+	if subsErr != nil {
+		t.Fatal(subsErr)
+	}
+
+
+	lastId := ""
+	loop: for {
+		select {
+		case d := <- subs.DataChan:
+			res := &struct{
+				Id json.Number `json:"id"`
+			}{}
+			json.Unmarshal(d, res)
+			if res.Id == "success" {
+				break loop
+			} else if string(res.Id) == lastId {
+				t.Fatal("Timestamp of last entity has not been set for polling")
+			}
+
+			lastId = string(res.Id)
+		case err := <- subs.ErrChan:
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
- When some entities (commands or notifications) are obtained polling pauses until timestamp of the latest entity isn't used for renewal of polling resource.
- Introduce map of HTTP **resources** to poll with **subscriptionId** as key
- TODO: consider changing architecture of transports and transport adapters to avoid synchronization between goroutines (one is on transport level does polling and another is on transport adapter level does transformation of subscription data received)